### PR TITLE
feat: add new vlc-dag demos of poc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "zchronod/zchronod",
     "demos/test_conflict",
     "demos/coll-tx",
+    "demos/vlc-dag"
 ]
 
 [profile.release]

--- a/crates/vlc/src/lib.rs
+++ b/crates/vlc/src/lib.rs
@@ -59,6 +59,12 @@ impl Clock {
         *value += 1;
     }
 
+    /// Get the clock count by id
+    pub fn get(&mut self, id: u128) -> u128 {
+        let value = self.values.entry(id).or_insert(0);
+        *value
+    }
+
     /// Reset the clock.
     pub fn clear(&mut self) {
         self.values.clear();
@@ -73,6 +79,52 @@ impl Clock {
             }
         }
     }
+
+    /// diff is bigger clock minus small clock
+    pub fn diff(&self, small: &Clock) -> Clock {
+        let mut ret = Clock::new();
+        for (id, v1) in &self.values {
+            let v2 = small.values.get(id).unwrap_or(&0);
+            ret.values.insert(*id, v1-v2);
+        }
+        ret
+    }
+
+    /// return index key of clock
+    pub fn index_key(&self) -> String {
+        let mut key = "".to_string();
+        for (index, value) in &self.values {
+            key = key + &index.to_string() + "-" + &value.to_string() + "-";
+        }
+        key
+    }
+
+    /// return common base clock of two clock
+    pub fn base_common(&self, other: &Clock) -> Clock {
+        let mut ret = Clock::new();
+        for (id, v1) in &self.values {
+            let v2 = other.values.get(id).unwrap_or(&0);
+            if v1 <= v2 {
+                ret.values.insert(*id, *v1);
+            } else {
+                ret.values.insert(*id, *v2);
+            }
+        }
+        ret
+    }
+
+    /// return true when all value is zero in clock dimensions
+    pub fn is_genesis(&self) -> bool {
+        let mut sum = 0;
+        for (_, v1) in &self.values {
+            sum += v1
+        }
+        if sum == 0 {
+            return true;
+        }
+        false
+    }
+    
 }
 
 #[cfg(test)]

--- a/crates/vlc/src/lib.rs
+++ b/crates/vlc/src/lib.rs
@@ -80,21 +80,25 @@ impl Clock {
         }
     }
 
-    /// diff is bigger clock minus small clock
-    pub fn diff(&self, small: &Clock) -> Clock {
+    /// Diff is local clock minus another clock
+    pub fn diff(&self, other: &Clock) -> Clock {
         let mut ret = Clock::new();
         for (id, v1) in &self.values {
-            let v2 = small.values.get(id).unwrap_or(&0);
-            ret.values.insert(*id, v1-v2);
+            let v2 = other.values.get(id).unwrap_or(&0);
+            if v1 > v2 {
+                ret.values.insert(*id, v1-v2);
+            } else {
+                ret.values.insert(*id, 0);
+            }
         }
         ret
     }
 
     /// return index key of clock
     pub fn index_key(&self) -> String {
-        let mut key = "".to_string();
+        let mut key: String = String::new();
         for (index, value) in &self.values {
-            key = key + &index.to_string() + "-" + &value.to_string() + "-";
+            key = format!("{}{}-{}-", key, index, value);
         }
         key
     }
@@ -115,14 +119,8 @@ impl Clock {
 
     /// return true when all value is zero in clock dimensions
     pub fn is_genesis(&self) -> bool {
-        let mut sum = 0;
-        for (_, v1) in &self.values {
-            sum += v1
-        }
-        if sum == 0 {
-            return true;
-        }
-        false
+        let sum: u128 = self.values.values().sum();
+        sum == 0
     }
     
 }

--- a/demos/vlc-dag/Cargo.toml
+++ b/demos/vlc-dag/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vlc-dag"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+vlc = { version = "0.1.0", path = "../../crates/vlc" }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1" }
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = [
+    "net",
+    "rt-multi-thread",
+    "macros",
+    "time",
+] }
+rand = { version = "0.8" }
+lmdb-rs = "0.7.6"

--- a/demos/vlc-dag/src/db_client/lldb_client.rs
+++ b/demos/vlc-dag/src/db_client/lldb_client.rs
@@ -1,0 +1,55 @@
+use crate::{lmdb::{DbFlags, DbHandle, Environment}, ClockInfo, MergeLog};
+
+#[derive(Clone)]
+pub struct VLCLLDb {
+    env: Environment,
+    merge_log: DbHandle,
+    clock_infos: DbHandle,
+    cur_count: DbHandle,
+}
+
+impl VLCLLDb {
+    pub fn new(path: &str) -> Self {
+        const USER_DIR: u32 = 0o777;
+        let env = Environment::new()
+            .max_dbs(5)
+            .open(path, USER_DIR)
+            .expect("Failed to open the environment");
+
+        let merge_log = env
+            .create_db("merge_log", DbFlags::empty())
+            .expect("Failed to create the merge_log database");
+
+        let clock_infos = env
+            .create_db("clock_infos", DbFlags::empty())
+            .expect("Failed to create the clock_infos database");
+
+        let cur_count = env
+            .create_db("cur_count", DbFlags::empty())
+            .expect("Failed to create the cur_count database");
+
+        VLCLLDb { env, merge_log, clock_infos, cur_count }
+    }
+
+    pub(crate) fn add_clock_infos(&mut self, key: String, clock_info: ClockInfo) {
+        let txn = self.env.new_transaction().unwrap();
+        let db = txn.bind(&self.clock_infos);
+
+        let _ = db.set(&key, &serde_json::to_string(&clock_info).unwrap());
+        println!("【insert clock to DB】: \nkey: {},\nvalue: {:#?}", key, clock_info);
+    }
+
+    pub(crate) fn add_merge_log(&mut self, key: String, merge_log: MergeLog) {
+        let txn = self.env.new_transaction().unwrap();
+        let db = txn.bind(&self.merge_log);
+
+        let _ = db.set(&key, &serde_json::to_string(&merge_log).unwrap());
+        println!("【insert merge_log to DB】:  \nkey: {},\nvalue: {:#?}", key, merge_log);
+    }
+
+    pub fn get_clock_info(&mut self, key: String) -> String {
+        let txn = self.env.new_transaction().unwrap();
+        let db = txn.bind(&self.clock_infos);
+        db.get::<&str>(&key).unwrap().to_string()
+    }
+}

--- a/demos/vlc-dag/src/db_client/lldb_client.rs
+++ b/demos/vlc-dag/src/db_client/lldb_client.rs
@@ -9,11 +9,15 @@ pub struct VLCLLDb {
 }
 
 impl VLCLLDb {
-    pub fn new(path: &str) -> Self {
-        const USER_DIR: u32 = 0o777;
+    pub fn new(path: &str, mode: Option<u32>) -> Self {
+        let mut USER_DIR_MODE: u32 = 0o777;
+        if let Some(mode) = mode {
+            USER_DIR_MODE = mode;
+        }
+
         let env = Environment::new()
             .max_dbs(5)
-            .open(path, USER_DIR)
+            .open(path, USER_DIR_MODE)
             .expect("Failed to open the environment");
 
         let merge_log = env
@@ -36,7 +40,7 @@ impl VLCLLDb {
         let db = txn.bind(&self.clock_infos);
 
         let _ = db.set(&key, &serde_json::to_string(&clock_info).unwrap());
-        println!("【insert clock to DB】: \nkey: {},\nvalue: {:#?}", key, clock_info);
+        println!("[insert clock to DB]: \nkey: {},\nvalue: {:#?}", key, clock_info);
     }
 
     pub(crate) fn add_merge_log(&mut self, key: String, merge_log: MergeLog) {
@@ -44,12 +48,12 @@ impl VLCLLDb {
         let db = txn.bind(&self.merge_log);
 
         let _ = db.set(&key, &serde_json::to_string(&merge_log).unwrap());
-        println!("【insert merge_log to DB】:  \nkey: {},\nvalue: {:#?}", key, merge_log);
+        println!("[insert merge_log to DB]:  \nkey: {},\nvalue: {:#?}", key, merge_log);
     }
 
     pub fn get_clock_info(&mut self, key: String) -> String {
         let txn = self.env.new_transaction().unwrap();
         let db = txn.bind(&self.clock_infos);
-        db.get::<&str>(&key).unwrap().to_string()
+        db.get::<&str>(&key).unwrap_or("").to_string()
     }
 }

--- a/demos/vlc-dag/src/db_client/lldb_test.rs
+++ b/demos/vlc-dag/src/db_client/lldb_test.rs
@@ -1,0 +1,85 @@
+use lmdb_rs as lmdb;
+use lmdb::{DbFlags, DbHandle, Environment};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+struct Commit {
+    pub id: String,
+    parent_ids: HashSet<String>,
+    message: String,
+}
+
+struct Repository {
+    env: Environment,
+    commits_db: DbHandle,
+}
+
+impl Repository {
+    
+    fn new(path: &str, db: &str) -> Self {
+        const USER_DIR: u32 = 0o777;
+        let env = Environment::new()
+            .max_dbs(5)
+            .open(path, USER_DIR)
+            .expect("Failed to open the environment");
+
+        let commits_db = env
+            .create_db(db, DbFlags::empty())
+            .expect("Failed to create the commits database");
+
+        Repository { env, commits_db }
+    }
+ 
+    fn add_commit(&mut self, commit: &Commit) {
+        // let db = self.env.get_default_db(DbFlags::empty()).unwrap();
+        let txn = self.env.new_transaction().unwrap();
+        let db = txn.bind(&self.commits_db);
+
+        let _ = db.set(&commit.id, &serde_json::to_string(&commit).unwrap());
+        println!("Get From DB: {}", db.get::<&str>(&commit.id).unwrap());
+    }
+
+    // other methods
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn submit_to_repo() {
+        let mut repo = Repository::new("./db", "commit");
+
+        let commit1 = Commit {
+            id: "commit1".to_string(),
+            parent_ids: HashSet::new(),
+            message: "Initial commit".to_string(),
+        };
+        repo.add_commit(&commit1);
+
+        let commit2 = Commit {
+            id: "commit2".to_string(),
+            parent_ids: vec!["commit1".to_string()].into_iter().collect(),
+            message: "Add feature X".to_string(),
+        };
+        repo.add_commit(&commit2);
+
+        let commit3 = Commit {
+            id: "commit3".to_string(),
+            parent_ids: vec!["commit1".to_string()].into_iter().collect(),
+            message: "Add feature Y".to_string(),
+        };
+        repo.add_commit(&commit3);
+
+        let commit4 = Commit {
+            id: "commit4".to_string(),
+            parent_ids: vec!["commit2".to_string(), "commit3".to_string()]
+                .into_iter()
+                .collect(),
+            message: "Merge feature X and Y".to_string(),
+        };
+        repo.add_commit(&commit4);
+    }
+}

--- a/demos/vlc-dag/src/db_client/mod.rs
+++ b/demos/vlc-dag/src/db_client/mod.rs
@@ -1,0 +1,2 @@
+pub mod lldb_client;
+mod lldb_test;

--- a/demos/vlc-dag/src/lib.rs
+++ b/demos/vlc-dag/src/lib.rs
@@ -1,0 +1,672 @@
+//! A vlc-dag application.
+//!
+//! The vlc-dag is base on the simple accumulator application. 
+//! Please reference on crates/accumulator. But add new features as follow:
+//! * defined the vertex and edge of the event & clock propagation dag.
+//! * support the LMDB to persistence storage for now，
+//! * maybe time-series db,like influxDB, or related postgre more suitable. (TD)
+//! * Support increment state sync with peers using p2p communication protocol.
+//! * so we can use the vertex and edge from db to reconstruct clock propagation dag.
+
+pub mod db_client;
+
+use clap::builder::Str;
+use db_client::lldb_client::VLCLLDb;
+use serde::{Deserialize, Serialize};
+use std::time::UNIX_EPOCH;
+use std::{cmp, time::SystemTime};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io::BufRead;
+use std::sync::{Arc, RwLock};
+use std::net::SocketAddr;
+use tokio::net::UdpSocket;
+
+use std::time;
+use tokio::{task::JoinHandle};
+use vlc::Clock;
+use lmdb_rs as lmdb;
+
+#[derive(Serialize, Deserialize, Debug)]
+enum Message {
+    FromClient(ClientMessage),
+    FromServer(ServerMessage),
+    Terminate,
+}
+
+/// Network configuration. Contains a list of server addresses.
+#[derive(Debug, Clone)]
+pub struct Configuration {
+    server_addrs: Vec<SocketAddr>,
+}
+
+impl Configuration {
+    /// Create configuration from a file.
+    pub fn from_file(path: &str) -> Self {
+        let mut config = Configuration {
+            server_addrs: Vec::new(),
+        };
+        let file = std::fs::File::open(path).unwrap();
+        let reader = std::io::BufReader::new(file);
+        for line in reader.lines() {
+            let addr = line.unwrap().parse().unwrap();
+            config.server_addrs.push(addr);
+        }
+        config
+    }
+}
+
+/// Client message type for the accumulator application. Each message contains
+/// a string.
+#[derive(Serialize, Deserialize, Debug)]
+struct ClientMessage {
+    item: String,
+}
+
+/// The current node state, which is a set of strings.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+enum ServerMessage {
+    EventTrigger(EventTrigger),
+    DiffReq(DiffReq),
+    DiffRsp(DiffRsp),
+    ActiveSync(ActiveSync)
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct EventTrigger {
+    clock_info: ClockInfo,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct DiffReq {
+    to : u128,
+    from_clock: ClockInfo,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct DiffRsp {
+    to : u128,
+    diffs: Vec<String>,
+    from: ClockInfo,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ActiveSync {
+    to : u128,
+    diffs: Vec<String>,
+    latest: ClockInfo,
+}
+
+/// A client node for the accumulator application.
+pub struct Client {
+    socket: UdpSocket,
+    config: Configuration,
+}
+
+impl Client {
+    /// Create a new client
+    pub async fn new(config: &Configuration) -> Self {
+        let s = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        Self {
+            socket: s,
+            config: config.clone(),
+        }
+    }
+
+    /// Disseminate a string to the accumulator network.
+    pub async fn disseminate(&mut self, item: &str, id: usize) {
+        let msg = Message::FromClient(ClientMessage {
+            item: String::from(item),
+        });
+        self.socket
+            .send_to(
+                serde_json::to_string(&msg).unwrap().as_bytes(),
+                self.config.server_addrs[id],
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Terminate a running accumulator server.
+    pub async fn terminate(&mut self, index: usize) {
+        let msg = Message::Terminate;
+        self.socket
+            .send_to(
+                serde_json::to_string(&msg).unwrap().as_bytes(),
+                self.config.server_addrs[index],
+            )
+            .await
+            .unwrap();
+    }
+}
+
+/// State of a server node.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ServerState {
+    clock_info: ClockInfo,
+    id: u128,
+    items: Vec<String>, // BtreeSet or HashSet can't keep event inserted order.
+    clock_to_eventid: HashMap<String, String>, // clock_id to event_id
+    message_id_set: BTreeSet<String>,
+}
+
+impl ServerState {
+    /// Create a new server state.
+    fn new(id: u128) -> Self {
+
+        Self {
+            clock_info: ClockInfo {
+                clock: Clock::new(),
+                id,
+                message_id: "".to_string(),
+                count: 0,
+                create_at: get_time_ms(),
+            },
+            id,
+            items: Vec::new(),
+            clock_to_eventid: HashMap::new(),
+            message_id_set: BTreeSet::new(),
+        }
+    }
+
+    /// Add items into the state. Returns true if resulting in a new state.
+    fn add(&mut self, items: Vec<String>) -> bool {
+        if items.len() < 1 {
+            false
+        } else {
+            for it in items.clone() {
+                // filter replicate message id
+                if self.message_id_set.contains(&it) {
+                    continue;
+                }
+                self.items.push(it.clone());
+                self.message_id_set.insert(it);
+            }
+            self.clock_info.clock.inc(self.id);
+            self.clock_info.count += 1;
+            if let Some(last) = items.last() {
+                self.clock_info.message_id = last.to_string();
+            }
+            true
+        }
+    }
+
+    /// Deprecated
+    /// Merge another ServerState into the current state. Returns true if
+    /// resulting in a new state (different from current and received
+    /// state). return first bool is need_broadcast, second bool is need_log
+    fn merge(&mut self, other: &Self) -> (bool, bool) {
+        match self.clock_info.clock.partial_cmp(&other.clock_info.clock) {
+            Some(cmp::Ordering::Equal) => return (false, false),
+            Some(cmp::Ordering::Greater) => return (false, false),
+            Some(cmp::Ordering::Less) => {
+                self.clock_info = other.clock_info.clone();
+                self.items = other.items.clone();
+                (false, true)
+            }
+            None => {
+                self.clock_info.clock.merge(&vec![&other.clock_info.clock]);
+                let add = self.add(other.items.clone());
+                (add, add)
+            }
+        }
+    }
+
+    fn handle_event_trigger(&mut self, msg: EventTrigger) -> Option<ServerMessage> {
+        match self.clock_info.clock.partial_cmp(&msg.clock_info.clock) {
+            Some(cmp::Ordering::Equal) => None,
+            Some(cmp::Ordering::Greater) => None,
+            Some(cmp::Ordering::Less) => {
+                let self_clock_info = ClockInfo::new(self.clock_info.clock.clone(), self.id, self.clock_info.message_id.clone(), 0);
+                let req = ServerMessage::DiffReq(DiffReq { from_clock: self_clock_info, to:  msg.clock_info.id });
+                Some(req)
+            }
+            None => {
+                // Todo: Calculate diff 
+                let base = self.clock_info.clock.base_common(&msg.clock_info.clock);
+                if base.is_genesis() {
+                    let req = ServerMessage::ActiveSync(ActiveSync { diffs: self.items.clone(), latest: self.clock_info.clone(), to: msg.clock_info.id });
+                    Some(req)
+                } else {
+                    if let Some(start_msg_id) = self.clock_to_eventid.get(&base.index_key()) {
+                        if let Some(diff_msg_ids) = get_suffix(&self.items, start_msg_id.to_string()) {
+                            // req diff and send self diff
+                            let req = ServerMessage::ActiveSync(ActiveSync { diffs: diff_msg_ids, latest: self.clock_info.clone(), to: msg.clock_info.id });
+                            Some(req)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_diff_req(&mut self, msg: DiffReq, db: Arc<RwLock<VLCLLDb>>) -> Option<ServerMessage> {
+        println!("Key-To-messageid: {:?}", self.clock_to_eventid);
+        if msg.from_clock.count == 0 {
+            let req = ServerMessage::DiffRsp(DiffRsp { diffs: self.items.clone(), from:self.clock_info.clone(), to: msg.from_clock.id });
+            return Some(req);
+        }
+        let empty_str = "".to_string();
+        let start_msg_id =self.clock_to_eventid.get(&msg.from_clock.clock.index_key()).unwrap_or(&empty_str);
+        // get begin from start_msg_id to end of state set
+        // Todo: simulator
+        if let Some(diff_msg_ids) = get_suffix(&self.items, start_msg_id.to_string()) {
+            let req = ServerMessage::DiffRsp(DiffRsp { diffs: diff_msg_ids,from:self.clock_info.clone(), to: msg.from_clock.id });
+            Some(req)
+        } else {
+            None
+        }
+    }
+
+    fn handle_diff_rsp(&mut self, msg: DiffRsp, db: Arc<RwLock<VLCLLDb>>) -> bool {
+        // Todo: simulator
+        match self.clock_info.clock.partial_cmp(&msg.from.clock) {
+            Some(cmp::Ordering::Equal) => {},
+            Some(cmp::Ordering::Greater) => {},
+            Some(cmp::Ordering::Less) | None => {
+                self.items.extend(msg.diffs);  // message id represent message 
+                self.clock_info = msg.from.clone();
+                self.clock_info.clock.inc(self.id);
+                self.clock_to_eventid.insert(msg.from.clock.index_key(), msg.from.message_id);
+                return true;
+            }
+        }
+        false
+    }
+
+    fn handle_active_sync(&mut self, msg: ActiveSync, db: Arc<RwLock<VLCLLDb>>) -> Option<ServerMessage> {
+        match self.clock_info.clock.partial_cmp(&msg.latest.clock) {
+            Some(cmp::Ordering::Equal) => None,
+            Some(cmp::Ordering::Greater) => None,
+            Some(cmp::Ordering::Less) => {
+                // Calculate clock diff 
+                self.items.extend(msg.diffs);  // message id represent message 
+                self.clock_info = msg.latest.clone();
+                self.clock_info.clock.inc(self.id);
+                None
+            }
+            None => {
+                // let from_clock = self.clock_info.clone();
+                // let pre_items = self.items.clone();
+                // Todo: Calculate diff 
+                // Todo: simulator
+                self.clock_info.clock.merge(&vec![&msg.latest.clock]);
+                let add = self.add(msg.diffs);
+                if !add {
+                    return None;
+                }
+                None
+
+                /* 
+                Follow code may led to recursive merge
+                let base = from_clock.clock.base_common(&msg.latest.clock);
+                if base.is_genesis() {
+                    let req = ServerMessage::ActiveSync(ActiveSync { diffs: pre_items, latest: self.clock_info.clone(), to: msg.latest.id });
+                    Some(req)
+                } else {
+                    if let Some(start_msg_id) = self.clock_to_eventid.get(&base.index_key()) {
+                        if let Some(diff_msg_ids) = get_suffix(&self.items, start_msg_id.to_string()) {
+                            // req diff and send self diff
+                            let req = ServerMessage::ActiveSync(ActiveSync { diffs: diff_msg_ids, latest: self.clock_info.clone(), to: msg.latest.id });
+                            Some(req)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                }
+                */
+            }
+        }
+
+    }
+    
+}
+
+/// Clock info sinker to db.
+/// id is server node id, count is the event count in this server.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ClockInfo {
+    pub clock: Clock,
+    pub id: u128,  
+    pub message_id: String,
+    pub count: u128,
+    pub create_at: u128,
+}
+
+impl ClockInfo {
+    fn new(clock: Clock, id: u128, message_id: String, count: u128) -> Self {
+        let create_at = get_time_ms();
+        Self { clock, id, message_id, count, create_at }
+    }
+}
+
+/// MergeLog sinker to db.
+/// id is server node id, count is the event count in this server.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct MergeLog {
+    from_id: u128,
+    to_id: u128,
+    start_count: u128,
+    end_count: u128,
+    s_clock_hash: Clock,    // todo: needs hash when use related-db
+    e_clock_hash: Clock,
+    merge_at: u128,
+}
+
+/// An accumulator server node. Each node maintains a UDP socket, and a set of
+/// strings as its internal state.
+pub struct Server {
+    config: Configuration,
+    index: usize,
+    socket: UdpSocket,
+    state: ServerState,
+    running: bool,
+    db: Arc<RwLock<VLCLLDb>>,
+}
+
+impl Server {
+    /// Create a new server
+    pub async fn new(config: &Configuration, index: usize, db: Arc<RwLock<VLCLLDb>>) -> Self {
+        let s = UdpSocket::bind(config.server_addrs[index]).await.unwrap();
+        Self {
+            config: config.clone(),
+            index,
+            socket: s,
+            state: ServerState::new(index.try_into().unwrap()),
+            running: false,
+            db,
+        }
+    }
+
+    /// Handle a message
+    async fn handle_msg(&mut self, msg: Message) {
+        match msg {
+            Message::FromClient(msg) => {
+                if self.state.add(Vec::from_iter(vec![msg.item.clone()])) {
+                    self.sinker_clock(msg.item.clone()).await;
+                    let msg = ServerMessage::EventTrigger(EventTrigger {
+                        clock_info: self.state.clock_info.clone(),
+                    });
+                    self.broadcast_state(msg).await;
+                }
+            }
+            Message::FromServer(msg) => {
+                println!("FromServer: {:?}", msg);
+                match msg {
+                    ServerMessage::EventTrigger(msg) => {
+                        if let Some(msg) = self.state.handle_event_trigger(msg) {
+                            self.broadcast_state(msg).await;
+                        }
+                    }
+                    ServerMessage::DiffReq(msg) => {
+                        if let Some(msg) = self.state.handle_diff_req(msg, self.db.clone()) {
+                            self.broadcast_state(msg).await;
+                        }
+                    }
+                    ServerMessage::DiffRsp(msg) => {
+                        // not need to broadcast
+                        let merged = self.state.handle_diff_rsp(msg.clone(), self.db.clone());
+                        if merged {
+                            self.sinker_merge_log(&msg.from).await;
+                        }
+                    }
+                    ServerMessage::ActiveSync(msg) => {
+                        if let Some(send_msg) = self.state.handle_active_sync(msg.clone(), self.db.clone()) {
+                            self.broadcast_state(send_msg).await;
+                        }
+
+                        self.sinker_merge_log(&msg.latest).await;
+                    }
+                    _ => { println!("[broadcast_state]: not support ServerMessage ")}
+                }
+            }
+            Message::Terminate => {
+                self.running = false;
+            }
+        }
+    }
+
+    /// sinker clock info to db
+    async fn sinker_clock(&mut self, message_id: String) {
+        let mut clock_infos = self.state.clock_info.clone();
+        let id = self.state.id;
+        let count = clock_infos.clock.get(self.state.id);
+        let key = id.to_string() + "-" + &count.to_string() + "-vertex";
+        let time = get_time_ms();
+        let clock_info = ClockInfo {
+            clock: clock_infos.clock,
+            id,
+            message_id: message_id.clone(),
+            count,
+            create_at: time,
+        };
+        self.db.write().unwrap().add_clock_infos(key, clock_info.clone());
+        self.state.clock_to_eventid.insert(clock_info.clock.index_key(), message_id.clone());
+    }
+
+    /// sinker merge action to db
+    async fn sinker_merge_log(&mut self, fclock_info: &ClockInfo) {
+        let mut clock_infos = self.state.clock_info.clone();
+        let to_id = self.state.id;
+        let tcount = clock_infos.clock.get(self.state.id);
+        let from_id = fclock_info.id;
+        let mut fclock = fclock_info.clone();
+        let fcount = fclock.clock.get(fclock_info.id);
+        let key = from_id.to_string() + "-" + &fcount.to_string()+ "-" + &to_id.to_string() + "-" + &tcount.to_string() + "-edge";
+        let time = get_time_ms();
+        let merge_log = MergeLog {
+            from_id,
+            to_id,
+            start_count: fcount,
+            end_count: tcount,
+            s_clock_hash: fclock.clock,
+            e_clock_hash: clock_infos.clock,
+            merge_at: time,
+        };
+        self.db.write().unwrap().add_merge_log(key, merge_log.clone());
+    }
+
+    /// direct send to someone node
+    async fn direct_send(&mut self, fmsg: ServerMessage) {
+        let mut index = 0;
+        let server_msg = Message::FromServer(fmsg.clone());
+        match fmsg.clone() {
+            ServerMessage::DiffReq(msg) => {
+                index = msg.to;
+            }
+            ServerMessage::DiffRsp(msg) => {
+                index = msg.to;
+            }
+            ServerMessage::ActiveSync(msg) => {
+                index = msg.to;
+            }
+            _ => { return }
+        }
+
+        let msg_index: usize = index.try_into().unwrap();
+        if self.index != msg_index {
+            self.socket
+                .send_to(
+                    serde_json::to_string(&server_msg).unwrap().as_bytes(),
+                    self.config.server_addrs[msg_index],
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    /// Broadcast current state to all other nodes in the network.
+    async fn broadcast_state(&mut self, msg: ServerMessage) {
+        let server_msg = Message::FromServer(msg.clone());
+        match msg {
+            ServerMessage::EventTrigger(_) => {
+                for i in 0..self.config.server_addrs.len() {
+                    if self.index != i {
+                        self.socket
+                            .send_to(
+                                serde_json::to_string(&server_msg).unwrap().as_bytes(),
+                                self.config.server_addrs[i],
+                            )
+                            .await
+                            .unwrap();
+                    }
+                }
+            }
+            _ => {
+                self.direct_send(msg).await;
+            }
+        }
+    }
+
+    /// Main event loop.
+    pub async fn run(&mut self) {
+        self.running = true;
+        while self.running {
+            let mut buf = [0; 1500];
+            let (n, _) = self.socket.recv_from(&mut buf).await.unwrap();
+            let msg: Message = serde_json::from_str(&String::from_utf8_lossy(&buf[..n])).unwrap();
+            self.handle_msg(msg).await;
+        }
+    }
+}
+
+fn get_time_ms() -> u128 {
+    let time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    time
+}
+
+fn get_suffix<T: PartialEq + Clone>(vec: &[T], target: T) -> Option<Vec<T>> {
+    let iter = vec.iter();
+    let suffix: Vec<T> = iter
+        .skip_while(|x| **x != target)
+        .skip(1) // Skip the target value itself
+        .cloned()
+        .collect();
+
+    if suffix.is_empty() {
+        None
+    } else {
+        Some(suffix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use super::*;
+
+    async fn start_servers(n_server: usize) -> (Configuration, Vec<JoinHandle<Vec<String>>>) {
+        let mut config = Configuration {
+            server_addrs: Vec::new(),
+        };
+        let port = 8000 + rand::thread_rng().gen_range(0..100) * 10;
+        for i in 0..n_server {
+            let addr = format!("127.0.0.1:{}", port + i).parse().unwrap();
+            config.server_addrs.push(addr);
+        }
+        let db = Arc::new(RwLock::new(VLCLLDb::new("./db")));
+        let mut handles = Vec::new();
+        for i in 0..n_server {
+            let c = config.clone();
+            let db_clone = db.clone(); 
+            handles.push(tokio::spawn(async move {
+                let mut server = Server::new(&c, i, db_clone).await;
+                server.run().await;
+                server.state.items
+            }));
+        }
+        (config, handles)
+    }
+
+    async fn collect_states(handles: Vec<JoinHandle<Vec<String>>>) -> Vec<Vec<String>> {
+        let mut states = Vec::new();
+        for handle in handles {
+            states.push(handle.await.unwrap());
+        }
+        states
+    }
+
+    async fn terminate(config: &Configuration) {
+        let mut client = Client::new(config).await;
+        for i in 0..config.server_addrs.len() {
+            client.terminate(i).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn single_server() {
+        // Start server
+        let (config, handles) = start_servers(1).await;
+        // Run client
+        let mut client = Client::new(&config).await;
+        client.disseminate("hello", 0).await;
+        // End test
+        tokio::time::sleep(time::Duration::from_millis(100)).await;
+        terminate(&config).await;
+        let states = collect_states(handles).await;
+        assert!(states[0][0] == "hello");
+    }
+
+    #[tokio::test]
+    async fn multi_servers() {
+        // Start servers
+        let (config, handles) = start_servers(10).await;
+        // Run client
+        let mut client = Client::new(&config).await;
+        client.disseminate("hello", 0).await;
+        client.disseminate("world", 0).await;
+        // End test
+        tokio::time::sleep(time::Duration::from_millis(100)).await;
+        terminate(&config).await;
+        let states = collect_states(handles).await;
+        assert!(states.iter().all(|s| s[0] == "hello"));
+        assert!(states.iter().all(|s| s[1] == "world"));
+        assert!(states.iter().all(|s| s.len() == 2));
+    }
+
+    #[tokio::test]
+    async fn multi_servers_multi_clients() {
+        let server_nums = 10;
+        // Start servers
+        let (config, handles) = start_servers(server_nums).await;
+        // Run client
+        let mut client = Client::new(&config).await;
+        for i in 0..server_nums {
+            let str = format!("{}-hello", i);
+            client.disseminate(&str, i).await;
+        }
+        // End test
+        tokio::time::sleep(time::Duration::from_millis(100)).await;
+        terminate(&config).await;
+        let states = collect_states(handles).await;
+        for value in states.clone() {
+            println!("{:?}", value);
+        }
+        assert!(states[0][0] == "0-hello");
+        assert!(states[1][0] == "1-hello");
+        assert!(states[8][0] == "8-hello");
+        assert!(states.iter().all(|s| s.len() == server_nums));
+    }
+
+    #[test]
+    fn test_suffix() {
+        let vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let target = 5;
+
+        if let Some(suffix) = get_suffix(&vec, target) {
+            assert!(suffix == vec![6, 7, 8, 9]);
+            println!("Suffix after {}: {:?}", target, suffix);
+        } else {
+            println!("Target {} not found in the vector", target);
+        }
+    }
+}


### PR DESCRIPTION
A vlc-dag application.

The vlc-dag is base on the simple accumulator application. 
Please reference on crates/accumulator. But add new features as follow:
  * defined the vertex and edge of the event & clock propagation dag.
  * support the LMDB to persistence storage for now，
  * maybe time-series db,like influxDB, or related postgre more suitable. (TD)
  * Support increment state sync with peers using p2p communication protocol.
  * so we can use the vertex and edge from db to reconstruct clock propagation dag.